### PR TITLE
Handles promise rejection for /daemonset endpoint.

### DIFF
--- a/src/server/express-app.js
+++ b/src/server/express-app.js
@@ -85,7 +85,10 @@ app.get('/daemonset', (req, res) => {
   k8sApi2.listNamespacedDaemonSet('default')
     .then((re) => {
       res.json(re.body);
-    });
+    })
+    .catch((err) => {
+      res.send(err);
+    })
 });
 
 


### PR DESCRIPTION
Should resolve #18 

Node now requires promise handling.  There was a missing catch on the daemonset endpoint.