### PR TITLE
Update ClusterRoleBinding API version

### DIFF
--- a/fabric8-rbac.yaml
+++ b/fabric8-rbac.yaml
@@ -8,7 +8,7 @@
 #  namespace: <namespace>
 
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
  name: fabric8-rbac


### PR DESCRIPTION
>Warning: rbac.authorization.k8s.io/v1beta1 ClusterRoleBinding is deprecated in v1.17+, unavailable in v1.22+; use rbac.authorization.k8s.io/v1 ClusterRoleBinding