### PR TITLE
ci: multi-arch Docker build + push to GHCR

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,11 @@
+.git
+.github
 .gitignore
+.dockerignore
 README.md
+LICENSE
 .DS_Store
+node_modules
+dist
 k8sed
 k8sgrider
-Dockerfile
-package-lock.json
-node_modules
-.dockerignore
-LICENSE

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,49 @@
+name: Build and push Docker image
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/spekt8
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=sha-,format=short
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ github.event_name == 'pull_request' && 'linux/amd64' || 'linux/amd64,linux/arm64,linux/arm/v7' }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
-# version 8 of node
-FROM node:8
+# syntax=docker/dockerfile:1
 
-# create a directory for client
-RUN mkdir -p /usr/src/app
-WORKDIR /usr/src/app
-
-# install app dependencies
-COPY package*.json ./
-
-RUN npm install 
-
-# bundle app source
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package.json ./
+RUN npm install --no-audit --no-fund
 COPY . .
+RUN npm run build
 
-# bind to port 3000
+FROM node:20-alpine
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=dev --no-audit --no-fund \
+    && npm cache clean --force
+COPY src/server ./src/server
+COPY --from=builder /app/dist ./dist
+USER node
 EXPOSE 3000
-CMD ["npm", "run", "server"]
+CMD ["node", "src/server/server.js"]


### PR DESCRIPTION
Sets up automated builds and addresses three long-standing issues at once.

## Changes
- **Dockerfile**: multi-stage build using `node:20-alpine` (was `node:8`, which went EOL in April 2019). Builder stage runs `npm run build` (which now actually works after #36). Runtime stage installs prod-only deps, copies built `dist/` and server source, runs as the non-root `node` user.
- **`.github/workflows/docker.yml`**:
  - On PRs: amd64-only validation build, **no push** (fast feedback)
  - On push to `master` and `workflow_dispatch`: multi-arch build for `linux/amd64`, `linux/arm64`, `linux/arm/v7`, pushed to `ghcr.io/spekt8/spekt8` with tags `:latest`, `:sha-*`, branch
  - Uses `cache-from`/`cache-to` GHA cache for buildx layers
- **`.dockerignore`**: cleaned up; excludes `.git`, `.github`, `dist`

## What this enables (addresses on merge)
- **#21** "Image only built for AMD64" — now tri-arch on every master push
- **#30** "Dockerhub image is not up to date" — replaced by a maintained GHCR image, auto-built on every commit
- **#33** "Support for Mac M1 (arm64)" — arm64 platform covered

## What's NOT in this PR
- The Deployment yaml still points at the legacy `elliotxkim/spekt8` image. Switching it to `ghcr.io/spekt8/spekt8:latest` (along with README updates and closing #21/#30/#33) is the next PR — gated on this one's first successful master-push build.

## Notes
- First master-push build may take 15–20 minutes because arm/v7 builds under QEMU emulation. Subsequent builds will be fast via GHA cache.
- ARM/v7 may surface dep-install issues if any deep transitive dep dropped arm/v7 support. We'll find out from CI; if it does, easy follow-up to drop arm/v7 and keep amd64 + arm64.