### PR TITLE
feat: publish multi-arch image to Docker Hub, wire manifests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - uses: actions/checkout@v4
 
@@ -19,19 +16,18 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
-      - name: Log in to GHCR
+      - name: Log in to Docker Hub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels)
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/spekt8
+          images: camillelambert/spekt8
           tags: |
             type=ref,event=branch
             type=sha,prefix=sha-,format=short

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ While the current app does not directly visualize any controllers (such as Deplo
 In addition to these views, nodes can be presented either in graphical or in table mode. The graphical mode is practical for obtaining a quick visual overview of your app, and its infrastructure and connections between all of the nodes. And when you switch to table mode, nodes are presented in a convenient list that displays the resources being consumed by processes, containers, and hosts.
 
 ## Deployment
-These instructions presume you have a Kubernetes cluster already running. 
+These instructions presume you have a Kubernetes cluster already running.
 
-An image of the application has been pushed to [Docker Hub](https://hub.docker.com/r/elliotxkim/spekt8/tags/) for those who would like to build the image directly from the public repository. 
+A maintained multi-architecture image (`linux/amd64`, `linux/arm64`, `linux/arm/v7`) is published to Docker Hub at [`camillelambert/spekt8`](https://hub.docker.com/r/camillelambert/spekt8). It's automatically rebuilt and pushed on every commit to `master`. Tags include `:latest` and per-commit `:sha-*`.
 
 SPEKT8 needs read access to a few Kubernetes resources (pods, services, ingresses, deployments, daemonsets) in the `default` namespace. Apply the RBAC manifest first to create a dedicated ServiceAccount with least-privilege read-only access, then apply the Deployment:
 

--- a/spekt8-deployment.yaml
+++ b/spekt8-deployment.yaml
@@ -15,6 +15,6 @@ spec:
       serviceAccountName: spekt8
       containers:
         - name: spekt8
-          image: elliotxkim/spekt8
+          image: camillelambert/spekt8:latest
           ports:
             - containerPort: 3000


### PR DESCRIPTION
Pivots image publishing from GHCR to Docker Hub, and points the Deployment + README at the new image. This is the final piece of the modernization series.

## Why Docker Hub (not GHCR)
GHCR was the original target (#37) and the build did publish there — but the `spekt8` org has a policy that prevents container packages from being made public, which would have left users with `ImagePullBackOff` on `kubectl apply`. Docker Hub doesn't have that constraint, defaults to public, and is more recognizable for anyone finding this repo from a K8s-ecosystem search.

## Changes
- **`.github/workflows/docker.yml`**: login to `docker.io` using `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets; image name `camillelambert/spekt8`; removed the now-unneeded `packages: write` permission.
- **`spekt8-deployment.yaml`**: `image: elliotxkim/spekt8` → `camillelambert/spekt8:latest`.
- **`README.md`**: replaced the stale link to the abandoned `elliotxkim/spekt8` Docker Hub image with the maintained `camillelambert/spekt8`, noting the supported architectures.

## On merge
- PR validation build runs amd64 only, no push (no secrets needed for the PR build).
- The master-push build runs the multi-arch buildx + pushes `:latest`, `:sha-*`, and `master` tags to `camillelambert/spekt8`.
- Closes **#21** (ARM support), **#30** (stale Docker Hub image), **#33** (M1/arm64 support).

## Verified before pushing
- Both repo secrets `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are set.
- The PR workflow under `pull_request` won't try to login or push, so this PR's CI will pass without needing the secrets.