### PR TITLE
chore: bump version to 2.0.0 for release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spekt8",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "Visualize your Kubernetes cluster in real time",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
One-line version bump in package.json so the v2.0.0 tag points at a commit where the internal version actually says 2.0.0. Pairs with the v2.0.0 release that captures the May 2026 modernization series.